### PR TITLE
[WIP] New: implement --init

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -6,25 +6,31 @@
 "use strict"
 
 const debug = require("debug")("eslint-cli")
-const debugMode = process.argv.indexOf("--debug") !== -1
+const isDebugMode = process.argv.indexOf("--debug") !== -1
+const isInit = process.argv.indexOf("--init") !== -1
 const cwd = process.cwd()
 
-if (debugMode) {
+if (isDebugMode) {
     require("debug").enable("eslint-cli")
 }
 
 debug("START", process.argv)
 debug("ROOT", cwd)
 
-const binPath = require("../lib/get-local-eslint")(cwd) || require("../lib/get-bin-eslint-js")(cwd)
-if (binPath != null) {
-    require(binPath)
+if (isInit) {
+    require("../lib/init")(cwd)
 }
 else {
-    //eslint-disable-next-line no-console
-    console.error(`
+    const binPath = require("../lib/get-local-eslint")(cwd) || require("../lib/get-bin-eslint-js")(cwd)
+    if (binPath != null) {
+        require(binPath)
+    }
+    else {
+        //eslint-disable-next-line no-console
+        console.error(`
 Could not find local ESLint.
 Please install ESLint by 'npm install --save-dev eslint'.
 `)
-    process.exitCode = 1
+        process.exitCode = 1
+    }
 }

--- a/lib/get-bin-eslint-js.js
+++ b/lib/get-bin-eslint-js.js
@@ -26,7 +26,7 @@ module.exports = (basedir) => {
             debug("FOUND '%s'", binPath)
             return binPath
         }
-        debug("NOT FOUND '%s'", binPath)
+        debug("NOT_FOUND '%s'", binPath)
 
         // Finish if package.json is found.
         if (fs.existsSync(path.join(dir, "package.json"))) {
@@ -39,6 +39,6 @@ module.exports = (basedir) => {
     }
     while (dir !== prevDir)
 
-    debug("NOT FOUND './bin/eslint.js'")
+    debug("NOT_FOUND './bin/eslint.js'")
     return null
 }

--- a/lib/init/common-questions.js
+++ b/lib/init/common-questions.js
@@ -1,0 +1,57 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+module.exports = {
+    es2015: () => ({
+        type: "confirm",
+        name: "es2015",
+        message: "Are you using ECMAScript 2015 features?",
+        default: false,
+    }),
+    modules: () => ({
+        type: "confirm",
+        name: "modules",
+        message: "Are you using ES modules?",
+        default: false,
+        when(answers) {
+            return answers.es2015 === true
+        },
+    }),
+    envs: () => ({
+        type: "checkbox",
+        name: "envs",
+        message: "Where will your code run?",
+        default: ["browser"],
+        choices: [
+            { name: "Browser", value: "browser" },
+            { name: "Node", value: "node" },
+        ],
+    }),
+    commonjs: () => ({
+        type: "confirm",
+        name: "commonjs",
+        message: "Do you use CommonJS?",
+        default: false,
+        when(answers) {
+            return !answers.modules && answers.envs.indexOf("browser") !== -1
+        },
+    }),
+    jsx: () => ({
+        type: "confirm",
+        name: "jsx",
+        message: "Do you use JSX?",
+        default: false,
+    }),
+    react: (context) => ({
+        type: "confirm",
+        name: "react",
+        message: "Do you use React?",
+        default: false,
+        when(answers) {
+            return answers.jsx && context.packageJsonPath != null
+        },
+    }),
+}

--- a/lib/init/get-local-eslint.js
+++ b/lib/init/get-local-eslint.js
@@ -11,19 +11,19 @@ const resolve = require("resolve")
  * Finds and tries executing a local eslint module.
  *
  * @param {string} basedir - A path of the directory that it starts searching.
- * @returns {string|null} The path of the local eslint module.
+ * @returns {object|null} The local eslint module.
  */
 module.exports = (basedir) => {
     try {
-        const binPath = resolve.sync("eslint/bin/eslint.js", { basedir })
+        const binPath = resolve.sync("eslint", { basedir })
         debug("FOUND '%s'", binPath)
-        return binPath
+        return require(binPath)
     }
     catch (err) {
         if ((err && err.code) !== "MODULE_NOT_FOUND") {
             throw err
         }
-        debug("NOT_FOUND 'eslint/bin/eslint.js'")
+        debug("NOT_FOUND 'eslint'")
         return null
     }
 }

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -46,19 +46,20 @@ module.exports = (cwd) => {
     let config = null
     let format = null
 
-    // Ask to choose the method to initialize.
     return Promise.resolve().then(() => {
         if (!packageJsonPath) {
             const error = new Error("package.json not found")
             error.code = "PACKAGE_JSON_NOT_FOUND"
             throw error
         }
+
+        // Ask to choose the method to initialize.
         return promptMethod()
     }).then(answers => {
         debug("METHOD '%s'", answers.method)
-        const promptConfig = require(`./prompt-config/${answers.method}`)
 
         // Ask to configure user's preference.
+        const promptConfig = require(`./prompt-config/${answers.method}`)
         return promptConfig(context)
     }).then(config0 => {
         debug("CONFIG '%j'", config0)
@@ -73,10 +74,20 @@ module.exports = (cwd) => {
         // Install dependencies into project-local (including ESLint itself).
         const installESLint = format.installESLint !== false
         return fetchPluginsAndConfigs(context, config, installESLint)
-    }).then(packages => {
-        debug("DEPS '%j'", packages)
-        return installPackages(context, packages)
-    }).then(() => {
+    }).then(packages =>
+        installPackages(context, packages)
+    ).then(() => {
+        // Execute postprocess if exists.
+        if (config.$postprocess != null) {
+            const postprocess = config.$postprocess
+            delete config.$postprocess
+
+            return postprocess()
+        }
+        return config
+    }).then(config0 => {
+        config = config0
+
         // Save the generated config.
         const filePath = path.join(cwd, `.eslintrc${format.fileType}`)
         return saveConfigFile(filePath, config)

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -1,0 +1,87 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const path = require("path")
+const debug = require("debug")("eslint-cli")
+const pkgUp = require("pkg-up")
+const fetchPluginsAndConfigs = require("./npm-util/fetch-plugins-and-configs")
+const installPackages = require("./npm-util/install-packages")
+const promptMethod = require("./prompt-method")
+const promptFormat = require("./prompt-format")
+const saveConfigFile = require("./save-config-file")
+
+//eslint-disable-next-line no-console
+const log = console.log.bind(console)
+
+// Error messages.
+const MESSAGES = Object.create(null)
+MESSAGES.NPM_NOT_FOUND = `
+The CLI command 'npm' was not found.
+It's required in order to manage dependent packages such as plugins/configs.
+
+Please ensure Node.js is installed correctly.
+`
+MESSAGES.PACKAGE_JSON_NOT_FOUND = `
+The file 'package.json' was not found.
+It's required in order to manage dependent packages such as config preset.
+
+Please do 'npm init' before 'eslint --init'.
+
+Further reading: https://docs.npmjs.com/cli/init
+`
+
+/**
+ * Initialize ESLint for the current project.
+ * @param {string} cwd The path to the current working directory.
+ * @returns {void}
+ */
+module.exports = (cwd) => {
+    debug("START --init on '%s'", cwd)
+
+    const packageJsonPath = pkgUp.sync(cwd)
+    const context = { cwd, packageJsonPath, log }
+    let config = null
+    let format = null
+
+    // Ask to choose the method to initialize.
+    return Promise.resolve().then(() => {
+        if (!packageJsonPath) {
+            const error = new Error("package.json not found")
+            error.code = "PACKAGE_JSON_NOT_FOUND"
+            throw error
+        }
+        return promptMethod()
+    }).then(answers => {
+        debug("METHOD '%s'", answers.method)
+        const promptConfig = require(`./prompt-config/${answers.method}`)
+
+        // Ask to configure user's preference.
+        return promptConfig(context)
+    }).then(config0 => {
+        debug("CONFIG '%j'", config0)
+        config = config0
+
+        // Ask to choose the saving format.
+        return promptFormat(context, config)
+    }).then(format0 => {
+        debug("FORMAT '%j'", format0)
+        format = format0
+
+        // Install dependencies into project-local (including ESLint itself).
+        const installESLint = format.installESLint !== false
+        return fetchPluginsAndConfigs(context, config, installESLint)
+    }).then(packages => {
+        debug("DEPS '%j'", packages)
+        return installPackages(context, packages)
+    }).then(() => {
+        // Save the generated config.
+        const filePath = path.join(cwd, `.eslintrc${format.fileType}`)
+        return saveConfigFile(filePath, config)
+    }).catch(error => {
+        log(MESSAGES[error.code] || error.stack)
+        process.exitCode = 1
+    })
+}

--- a/lib/init/inspect-util/get-option-patterns.js
+++ b/lib/init/inspect-util/get-option-patterns.js
@@ -1,0 +1,230 @@
+/**
+ * @author Ian VanSchooten
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const debug = require("debug")("eslint-cli")
+const get = require("lodash/get")
+const MAX_COMPLEXITY = 255
+
+/**
+ * Resolve $ref properties.
+ * @param {object} schema The current schema.
+ * @param {object} root The root object of the current schema.
+ * @returns {object} The schema.
+ */
+function resolveRef(schema, root) {
+    if (schema == null || typeof schema !== "object") {
+        return schema
+    }
+    root = root || schema //eslint-disable-line no-param-reassign
+
+    if (Array.isArray(schema)) {
+        for (const element of schema) {
+            resolveRef(element, root)
+        }
+    }
+    else {
+        for (const key of Object.keys(schema)) {
+            resolveRef(schema[key], root)
+        }
+    }
+
+    // $ref があれば解決する
+    if (typeof schema.$ref === "string") {
+        const refObj = get(root, schema.$ref.slice(2).split("/"))
+        if (refObj) {
+            for (const key of Object.keys(refObj)) {
+                if (schema[key] === undefined) {
+                    schema[key] = refObj[key]
+                }
+            }
+        }
+        else {
+            debug("INSPECT $ref '%s' was not found.", schema.$ref)
+        }
+        delete schema.$ref
+    }
+
+    return schema
+}
+
+/**
+ * Normalize a given schema object as an array.
+ * @param {object|Array} schema A schema object to normalize.
+ * @returns {object} The normalized schema.
+ */
+function normalizeSchema(schema) {
+    if (schema && !Array.isArray(schema)) {
+        return resolveRef(schema)
+    }
+    return resolveRef({
+        type: "array",
+        items: schema || [],
+    })
+}
+
+/**
+ * Iterate patterns of a given schema object.
+ * @param {Array} items The 'schema.items'.
+ * @param {number} index The current index.
+ * @param {Array} basePattern The patterns of the previous index.
+ * @returns {IterableIterator<Array>} The patterns.
+ */
+function* iteratePatternsOfArray(items, index, basePattern) {
+    const isLast = (index === items.length - 1)
+
+    for (const elementPattern of iteratePatterns(items[index])) {
+        if (elementPattern === undefined) {
+            yield undefined
+            break
+        }
+
+        basePattern[index] = elementPattern
+        if (isLast) {
+            yield basePattern.slice(0)
+        }
+        else {
+            yield* iteratePatternsOfArray(items, index + 1, basePattern)
+        }
+    }
+}
+
+/**
+ * Iterate patterns of a given schema object.
+ * @param {object} properties The 'schema.properties'.
+ * @param {Array} propertyNames The 'Object.keys(schema.properties)'.
+ * @param {number} index The current index.
+ * @param {object} basePattern The patterns of the previous index.
+ * @returns {IterableIterator<Array>} The patterns.
+ */
+function* iteratePatternsOfObject(properties, propertyNames, index, basePattern) {
+    const isLast = (index === propertyNames.length - 1)
+    const propertyName = propertyNames[index]
+
+    for (const elementPattern of iteratePatterns(properties[propertyName])) {
+        if (elementPattern === undefined) {
+            delete basePattern[propertyName]
+        }
+        else {
+            basePattern[propertyName] = elementPattern
+        }
+
+        if (isLast) {
+            yield Object.assign({}, basePattern)
+        }
+        else {
+            yield* iteratePatternsOfObject(properties, propertyNames, index + 1, basePattern)
+        }
+    }
+}
+
+/**
+ * Iterate patterns of a given schema object.
+ * @param {object} schema A schema object to iterate patterns.
+ * @returns {IterableIterator<Array>} The patterns.
+ */
+function* iteratePatterns(schema) { //eslint-disable-line complexity
+    if (schema.allOf) {
+        debug("INSPECT not-supported type: 'allOf'")
+        yield undefined
+        return
+    }
+    if (schema.anyOf || schema.oneOf) {
+        for (const element of schema.anyOf || schema.oneOf) {
+            yield* iteratePatterns(element)
+        }
+        return
+    }
+    if (schema.enum) {
+        yield* schema.enum
+        return
+    }
+
+    switch (schema.type) {
+        case "boolean":
+            yield true
+            yield false
+            break
+
+        case "number":
+        case "string":
+            debug("INSPECT non-supported type: '%s'", schema.type)
+            yield undefined
+            break
+
+        case "array":
+            if (Array.isArray(schema.items)) {
+                if (schema.items.length >= 1) {
+                    yield* iteratePatternsOfArray(schema.items, 0, [])
+                }
+            }
+            else {
+                debug("INSPECT non-supported type: 'array' with 'schema.items' is not an array.")
+                yield undefined
+            }
+            break
+
+        case "object":
+            if (schema.additionalProperties) {
+                debug("INSPECT non-supported type: 'object' with 'schema.additionalProperties'.")
+                yield undefined
+            }
+            else {
+                const propertyNames = Object.keys(schema.properties || {})
+                if (propertyNames.length >= 1) {
+                    yield* iteratePatternsOfObject(schema.properties, Object.keys(schema.properties), 0, {})
+                }
+            }
+            break
+
+        default:
+            debug("INSPECT unknown type: '%s'", schema.type)
+            yield undefined
+    }
+}
+
+/**
+ * Load rules and create the map of option patterns.
+ * @param {eslint.Linter} linter The linter object to load rules.
+ * @returns {Array<{ruleId:string,pattern:object}>} The array of option patterns.
+ */
+module.exports = (linter) => {
+    const result = []
+
+    for (const entry of linter.getRules()) {
+        const ruleId = entry[0]
+        const meta = entry[1].meta
+        if (meta.deprecated || meta.docs.recommended) {
+            continue
+        }
+
+        const schema = normalizeSchema(meta.schema)
+        const patterns = [{ [ruleId]: "error" }]
+
+        for (const pattern of iteratePatterns(schema)) {
+            if (pattern === undefined) {
+                debug("INSPECT check '%s' rule only without options because it has non-supported pattern.", ruleId)
+                patterns.length = 1
+                break
+            }
+
+            pattern.unshift("error")
+            patterns.push({ [ruleId]: pattern })
+
+            if (patterns.length > MAX_COMPLEXITY) {
+                debug("INSPECT check '%s' rule only without options because it has too many option patterns.", ruleId)
+                patterns.length = 1
+                break
+            }
+        }
+
+        for (const pattern of patterns) {
+            result.push({ ruleId, pattern })
+        }
+    }
+
+    return result
+}

--- a/lib/init/inspect-util/inspect.js
+++ b/lib/init/inspect-util/inspect.js
@@ -1,0 +1,205 @@
+/**
+ * @author Ian VanSchooten
+ * @author Ilya Volodin
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const fs = require("fs")
+const path = require("path")
+const debug = require("debug")("eslint-cli")
+const PQueue = require("p-queue")
+const Progress = require("progress")
+const resolvePath = require("resolve").sync
+const getOptionPatterns = require("./get-option-patterns")
+
+/**
+ * Read a file.
+ * @param {string} filePath A path to a target file.
+ * @returns {Promise<string>} The content of the file.
+ */
+function readFile(filePath) {
+    return new Promise((resolve, reject) => {
+        fs.readFile(filePath, "utf8", (error, code) => {
+            if (error) {
+                reject(error)
+            }
+            else {
+                resolve(code)
+            }
+        })
+    })
+}
+
+/**
+ * Inspection context.
+ * This has the local `eslint` instance to inspect source codes.
+ *
+ * TODO: The inspection logic requires some private files of ESLint.
+ */
+class InspectionContext {
+    /**
+     * Initialize this InspectionContext.
+     * @param {object} initContext The context.
+     * @param {string} initContext.cwd The path to the current working directory.
+     * @param {string|null} initContext.packageJsonPath The path to `package.json` file if exists.
+     * @param {function} initContext.log The function to display log messages.
+     */
+    constructor(initContext) {
+        const opts = { basedir: initContext.cwd }
+        const eslintPath = resolvePath("eslint", opts)
+        const globUtilPath = path.join(path.dirname(eslintPath), "util/glob-util")
+
+        this.cwd = initContext.cwd
+        this.log = initContext.log
+        this.eslint = require(eslintPath)
+        this.globUtil = require(globUtilPath)
+        this.linter = new this.eslint.Linter()
+        this.optionPatterns = getOptionPatterns(this.linter)
+
+        Object.freeze(this)
+    }
+
+    /**
+     * Get the list of file paths of given glob patterns.
+     * @param {string[]} patterns Glob patterns to lookup.
+     * @returns {string[]} The file paths.
+     */
+    listFiles(patterns) {
+        const opts = { cwd: this.cwd }
+        const patterns2 = this.globUtil.resolveFileGlobPatterns(patterns, opts)
+
+        return this.globUtil.listFilesToProcess(patterns2, opts)
+            .filter(fileInfo => !fileInfo.ignored)
+            .map(fileInfo => fileInfo.filename)
+    }
+
+    /**
+     * Normalize a given config.
+     * @param {object} baseConfig The base config to inspect.
+     * @returns {object} The normalized config object.
+     */
+    normalizeConfig(baseConfig) {
+        return new this.eslint.CLIEngine({ baseConfig, useEslintrc: false })
+            .getConfigForFile("a.js")
+    }
+
+    /**
+     * Inspect a file.
+     * @param {object} baseConfig The base config to inspect.
+     * @param {string} filePath The path to the target file.
+     * @param {Set<{ruleId:string,pattern:object}>} optionPatternCandidates The option patterns. This set is mutated.
+     * @returns {Promise<void>} -
+     */
+    inspectFile(baseConfig, filePath, optionPatternCandidates) {
+        return readFile(filePath).then(sourceCodeText => {
+            const config = Object.assign({}, baseConfig)
+            let sourceCode = null
+
+            // Check all candidates on this file.
+            for (const candidate of optionPatternCandidates) {
+                try {
+                    config.rules = candidate.pattern
+                    const messages = this.linter.verify(sourceCode || sourceCodeText, config, filePath)
+                    const count = messages.reduce(
+                        (c, m) => (m.ruleId === candidate.ruleId ? c + 1 : c),
+                        0
+                    )
+
+                    // Skip this file if syntax errors exist.
+                    if (messages.length >= 1 && messages[0].fatal) {
+                        debug("INSPECT skip this file because it has syntax error: '%s'.", filePath)
+                        break
+                    }
+
+                    // Reuse the source code object to improve performance.
+                    if (!sourceCode) {
+                        sourceCode = this.linter.getSourceCode()
+                    }
+
+                    // Delete the entry from the candidate set if errors exist.
+                    if (count >= 1) {
+                        debug("INSPECT %j reports %d errors on '%s'.", candidate.pattern, count, filePath)
+                        optionPatternCandidates.delete(candidate)
+                    }
+                }
+                catch (error) {
+                    debug("INSPECT ERROR with %j %s", { filePath, candidate }, error.stack)
+                }
+            }
+        })
+    }
+
+    /**
+     * Inspect files.
+     * @param {object} baseConfig The base config to inspect.
+     * @param {string[]} patterns The glob patterns of target files.
+     * @returns {Promise<object>} The result config.
+     */
+    inspectFiles(baseConfig, patterns) {
+        const config = this.normalizeConfig(baseConfig)
+        const files = this.listFiles(patterns)
+        const optionPatterns = new Set(this.optionPatterns)
+        const queue = new PQueue({ concurrency: 8 })
+        const peogress = debug.enabled ? null : new Progress(
+            "Determining Config: :percent [:bar] :elapseds elapsed, eta :etas",
+            { width: 30, total: files.length }
+        )
+
+        this.log("") // empty line.
+        if (peogress) {
+            peogress.tick(0) // progress bar.
+        }
+
+        debug("INSPECT %d patterns exist.", optionPatterns.size)
+        for (const filePath of files) {
+            // Use queue (concurrency:8) to read while linting.
+            queue.add(() =>
+                this.inspectFile(config, filePath, optionPatterns)
+                    .then(() => peogress && peogress.tick())
+            )
+        }
+
+        return queue.onIdle().then(() => {
+            debug("INSPECT %d patterns passed.", optionPatterns.size)
+            const ruleDefMap = this.linter.getRules()
+            const rules = {}
+            let countEnabled = 0
+            let countDisabled = 0
+
+            // Collect enabled rules.
+            for (const entry of optionPatterns) {
+                if (!rules[entry.ruleId]) {
+                    debug("INSPECT adopted %j.", entry.pattern)
+                    rules[entry.ruleId] = entry.pattern[entry.ruleId]
+                    countEnabled += 1
+                }
+            }
+
+            // Collect disabled rules.
+            for (const ruleId of Object.keys(config.rules)) {
+                if (!rules[ruleId] && config.rules[ruleId] === "off" && !ruleDefMap.get(ruleId).meta.deprecated) {
+                    rules[ruleId] = "off"
+                    countDisabled += 1
+                }
+            }
+
+            this.log(`Enabled ${countEnabled} out of ${countEnabled + countDisabled} rules based on ${patterns.join(", ")}.`)
+            return Object.assign({}, baseConfig, { rules })
+        })
+    }
+}
+
+/**
+ * Inspect files.
+ * @param {object} context The context info.
+ * @param {string} context.cwd The path to the current working directory.
+ * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} context.log The function to display log messages.
+ * @param {object} config The base config to inspect.
+ * @param {string[]} patterns The glob patterns of target files.
+ * @returns {Promise<object>} The result config.
+ */
+module.exports = (context, config, patterns) =>
+    new InspectionContext(context).inspectFiles(config, patterns)

--- a/lib/init/npm-util/fetch-peer-dependencies.js
+++ b/lib/init/npm-util/fetch-peer-dependencies.js
@@ -1,0 +1,42 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const debug = require("debug")("eslint-cli")
+const spawnNpm = require("./spawn-npm")
+
+// Map<string, Promise<object>>
+const cache = new Map()
+
+/**
+ * Fetch `peerDependencies` of a given package with `npm show` command.
+ * @param {object} context The context info.
+ * @param {string} context.cwd The path to the current working directory.
+ * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} context.log The function to display log messages.
+ * @param {string} packageName The package name to fetch peerDependencies.
+ * @returns {Promise<object>} Gotten peerDependencies.
+ */
+module.exports = (context, packageName) => {
+    let promise = cache.get(packageName)
+    if (promise != null) {
+        debug("CACHE_HIT npm show --json %s peerDependencies", packageName)
+    }
+    else {
+        context.log("Checking peer dependencies of '%s'.", packageName)
+        promise = spawnNpm(
+            ["show", "--json", packageName, "peerDependencies"],
+            { cwd: context.cwd, encoding: "utf8" }
+        ).then(jsonText => JSON.parse(jsonText.trim() || "{}"))
+
+        cache.set(packageName, promise)
+    }
+
+    promise.then(result => {
+        debug("PEER_DEPS '%s' → %j", packageName, result)
+    })
+
+    return promise
+}

--- a/lib/init/npm-util/fetch-plugins-and-configs.js
+++ b/lib/init/npm-util/fetch-plugins-and-configs.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const debug = require("debug")("eslint-cli")
 const fetchPeerDependencies = require("./fetch-peer-dependencies")
 
 /**
@@ -52,8 +51,6 @@ module.exports = (context, config, installESLint) => {
         if (!installESLint && depMap.eslint != null) {
             delete depMap.eslint
         }
-
-        debug("DEPS %j", depMap)
         return Object.keys(depMap).map(name => `${name}@${depMap[name]}`)
     })
 }

--- a/lib/init/npm-util/fetch-plugins-and-configs.js
+++ b/lib/init/npm-util/fetch-plugins-and-configs.js
@@ -1,0 +1,59 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const debug = require("debug")("eslint-cli")
+const fetchPeerDependencies = require("./fetch-peer-dependencies")
+
+/**
+ * Fetch the dependency names of a given config object.
+ * @param {object} context The context info.
+ * @param {string} context.cwd The path to the current working directory.
+ * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} context.log The function to display log messages.
+ * @param {object} config A config object to get.
+ * @param {boolean} installESLint The flag to install eslint package.
+ * @returns {Promise<string[]>} The dependency names.
+ */
+module.exports = (context, config, installESLint) => {
+    const depMap = Object.create(null)
+    const promises = []
+
+    if (config.plugins != null) {
+        for (const pluginName of config.plugins) {
+            depMap[`eslint-plugin-${pluginName}`] = "latest"
+            promises.push(
+                fetchPeerDependencies(context, `eslint-plugin-${pluginName}@latest`)
+                    .then(result => Object.assign(depMap, result))
+            )
+        }
+    }
+    if (config.extends != null) {
+        const configNames = Array.isArray(config.extends) ? config.extends : [config.extends]
+        for (const configName of configNames) {
+            if (configName.startsWith("eslint:") || configName.startsWith("plugin:")) {
+                continue
+            }
+
+            depMap[`eslint-config-${configName}`] = "latest"
+            promises.push(
+                fetchPeerDependencies(context, `eslint-config-${configName}@latest`)
+                    .then(result => Object.assign(depMap, result))
+            )
+        }
+    }
+
+    return Promise.all(promises).then(() => {
+        if (installESLint && depMap.eslint == null) {
+            depMap.eslint = "latest"
+        }
+        if (!installESLint && depMap.eslint != null) {
+            delete depMap.eslint
+        }
+
+        debug("DEPS %j", depMap)
+        return Object.keys(depMap).map(name => `${name}@${depMap[name]}`)
+    })
+}

--- a/lib/init/npm-util/install-packages.js
+++ b/lib/init/npm-util/install-packages.js
@@ -1,0 +1,30 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const debug = require("debug")("eslint-cli")
+const spawnNpm = require("./spawn-npm")
+
+/**
+ * Install given packages with `npm install --save-dev` command.
+ * @param {object} context The context info.
+ * @param {string} context.cwd The path to the current working directory.
+ * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} context.log The function to display log messages.
+ * @param {string[]} packageNames The package names to install.
+ * @returns {Promise<void>} -
+ */
+module.exports = (context, packageNames) => {
+    if (packageNames.length === 0) {
+        debug("NO_DEPS")
+        return Promise.resolve()
+    }
+
+    context.log("Installing dependencies:", packageNames.map(name => `\n    ${name}`).join(""))
+    return spawnNpm(
+        ["install", "--save-dev"].concat(packageNames),
+        { cwd: context.cwd, stdio: "inherit" }
+    )
+}

--- a/lib/init/npm-util/spawn-npm.js
+++ b/lib/init/npm-util/spawn-npm.js
@@ -1,0 +1,49 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const Buffer = require("buffer").Buffer
+const spawn = require("cross-spawn")
+const debug = require("debug")("eslint-cli")
+
+/**
+ * Spawn `npm` with the given arguments.
+ * @param {string[]} args The arguments.
+ * @param {object} options Options of `child_process.spawn`.
+ * @returns {Promise<string|null>} The string of `stdout` of the child process.
+ * If `options.stdio` is `"inherit"`, this returns nothing.
+ */
+module.exports = (args, options) =>
+    new Promise((resolve, reject) => {
+        const needsStdout = options.stdio !== "inherit"
+
+        debug("EXEC npm %s", args.join(" "))
+        const cp = spawn("npm", args, options)
+
+        cp.on("error", (error) => {
+            debug("EXEC error '%s'", error.message)
+            if ((error && error.code) === "ENOENT") {
+                error.code = "NPM_NOT_FOUND"
+            }
+            reject(error)
+        })
+
+        const stdoutChunks = []
+        if (needsStdout) {
+            cp.stdout.on("data", (chunk) => {
+                stdoutChunks.push(chunk)
+            })
+        }
+
+        cp.on("close", (exitCode) => {
+            debug("EXEC finish '%s'", String(exitCode))
+            if (exitCode) {
+                reject(new Error(`npm exited with non-zero code: ${exitCode}`))
+            }
+            else {
+                resolve(needsStdout ? Buffer.concat(stdoutChunks).toString() : null)
+            }
+        })
+    })

--- a/lib/init/prompt-config/files.js
+++ b/lib/init/prompt-config/files.js
@@ -8,7 +8,8 @@ const debug = require("debug")("eslint-cli")
 const inquirer = require("inquirer")
 const set = require("lodash/set")
 const questions = require("../common-questions")
-const inspectSourceCode = require("../inspect-source-code")
+const inspectSourceCode = require("../inspect-util/inspect")
+const SP = /\s+/g
 
 /**
  * Prompt the user's style.
@@ -16,7 +17,7 @@ const inspectSourceCode = require("../inspect-source-code")
  * @param {string} context.cwd The path to the current working directory.
  * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
  * @param {function} context.log The function to display log messages.
- * @returns {Promise<FilesPromptResult>} The result of the prompt.
+ * @returns {Promise<object>} The created config object.
  */
 module.exports = (context) =>
     inquirer.prompt([
@@ -24,8 +25,11 @@ module.exports = (context) =>
             type: "input",
             name: "patterns",
             message: "Which file(s), path(s), or glob(s) should be examined?",
+            filter(input) {
+                return input.trim().split(SP).filter(Boolean)
+            },
             validate(input) {
-                if (input.trim().length === 0) {
+                if (input.length === 0) {
                     return "You must tell us what code to examine. Try again."
                 }
                 return true
@@ -39,7 +43,9 @@ module.exports = (context) =>
         questions.react(context),
     ]).then(answers => {
         debug("ANSWERS %j", answers)
-        const config = {}
+        const config = {
+            extends: ["eslint:recommended"],
+        }
 
         if (answers.es2015) {
             set(config, "env.es6", true)
@@ -56,12 +62,16 @@ module.exports = (context) =>
 
         if (answers.jsx) {
             if (answers.react) {
-                config.extends = ["plugin:react/recommended"]
+                config.extends.push("plugin:react/recommended")
                 config.plugins = ["react"]
                 set(config, "parserOptions.ecmaFeatures.experimentalObjectRestSpread", true)
             }
             set(config, "parserOptions.ecmaFeatures.jsx", true)
         }
 
-        return inspectSourceCode(config, answers.patterns, context.cwd)
+        // Inspect files after install deps.
+        config.$postprocess =
+            inspectSourceCode.bind(null, context, config, answers.patterns)
+
+        return config
     })

--- a/lib/init/prompt-config/files.js
+++ b/lib/init/prompt-config/files.js
@@ -1,0 +1,67 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const debug = require("debug")("eslint-cli")
+const inquirer = require("inquirer")
+const set = require("lodash/set")
+const questions = require("../common-questions")
+const inspectSourceCode = require("../inspect-source-code")
+
+/**
+ * Prompt the user's style.
+ * @param {object} context The context info.
+ * @param {string} context.cwd The path to the current working directory.
+ * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} context.log The function to display log messages.
+ * @returns {Promise<FilesPromptResult>} The result of the prompt.
+ */
+module.exports = (context) =>
+    inquirer.prompt([
+        {
+            type: "input",
+            name: "patterns",
+            message: "Which file(s), path(s), or glob(s) should be examined?",
+            validate(input) {
+                if (input.trim().length === 0) {
+                    return "You must tell us what code to examine. Try again."
+                }
+                return true
+            },
+        },
+        questions.es2015(context),
+        questions.modules(context),
+        questions.envs(context),
+        questions.commonjs(context),
+        questions.jsx(context),
+        questions.react(context),
+    ]).then(answers => {
+        debug("ANSWERS %j", answers)
+        const config = {}
+
+        if (answers.es2015) {
+            set(config, "env.es6", true)
+            if (answers.modules) {
+                set(config, "parserOptions.sourceType", "module")
+            }
+        }
+        if (answers.commonjs) {
+            set(config, "env.commonjs", true)
+        }
+        for (const envKey of answers.envs) {
+            set(config, `env.${envKey}`, true)
+        }
+
+        if (answers.jsx) {
+            if (answers.react) {
+                config.extends = ["plugin:react/recommended"]
+                config.plugins = ["react"]
+                set(config, "parserOptions.ecmaFeatures.experimentalObjectRestSpread", true)
+            }
+            set(config, "parserOptions.ecmaFeatures.jsx", true)
+        }
+
+        return inspectSourceCode(config, answers.patterns, context.cwd)
+    })

--- a/lib/init/prompt-config/guide.js
+++ b/lib/init/prompt-config/guide.js
@@ -1,0 +1,42 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const debug = require("debug")("eslint-cli")
+const inquirer = require("inquirer")
+
+/**
+ * Prompt the method to configure ESLint.
+ * @param {object} _context The context info.
+ * @param {string} _context.cwd The path to the current working directory.
+ * @param {string|null} _context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} _context.log The function to display log messages.
+ * @returns {Promise<object>} The created config object.
+ */
+module.exports = (_context) =>
+    inquirer.prompt([
+        {
+            type: "list",
+            name: "styleguide",
+            message: "Which style guide do you want to follow?",
+            choices: [
+                { name: "Google", value: "google" },
+                { name: "Airbnb", value: "airbnb-base" },
+                { name: "Standard", value: "standard" },
+            ],
+        },
+        {
+            type: "confirm",
+            name: "react",
+            message: "Do you use React?",
+            default: false,
+            when(answers) {
+                return answers.styleguide === "airbnb-base"
+            },
+        },
+    ]).then(answers => {
+        debug("ANSWERS %j", answers)
+        return { extends: (answers.react ? "airbnb" : answers.styleguide) }
+    })

--- a/lib/init/prompt-config/style.js
+++ b/lib/init/prompt-config/style.js
@@ -1,0 +1,103 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const debug = require("debug")("eslint-cli")
+const inquirer = require("inquirer")
+const set = require("lodash/set")
+const questions = require("../common-questions")
+
+/**
+ * Create configuration object by interactions.
+ *
+ * @param {object} context The context info.
+ * @param {string} context.cwd The path to the current working directory.
+ * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} context.log The function to display log messages.
+ * @returns {Promise<object>} The created config object.
+ */
+module.exports = (context) =>
+    inquirer.prompt([
+        questions.es2015(context),
+        questions.modules(context),
+        questions.envs(context),
+        questions.commonjs(context),
+        questions.jsx(context),
+        questions.react(context),
+        {
+            type: "list",
+            name: "indent",
+            message: "What style of indentation do you use?",
+            default: "tab",
+            choices: [
+                { name: "Tabs", value: "tab" },
+                { name: "4 spaces", value: 4 },
+                { name: "2 spaces", value: 2 },
+            ],
+        },
+        {
+            type: "list",
+            name: "quotes",
+            message: "What quotes do you use for strings?",
+            default: "double",
+            choices: [
+                { name: "Double", value: "double" },
+                { name: "Single", value: "single" },
+            ],
+        },
+        {
+            type: "list",
+            name: "linebreak",
+            message: "What line endings do you use?",
+            default: "unix",
+            choices: [
+                { name: "Unix (LF)", value: "unix" },
+                { name: "Windows (CRLF)", value: "windows" },
+            ],
+        },
+        {
+            type: "confirm",
+            name: "semi",
+            message: "Do you require semicolons?",
+            default: true,
+        },
+    ]).then(answers => {
+        debug("ANSWERS %j", answers)
+
+        const config = {
+            extends: ["eslint:recommended"],
+            rules: {
+                "indent": ["error", answers.indent],
+                "quotes": ["error", answers.quotes],
+                "linebreak-style": ["error", answers.linebreak],
+                "semi": ["error", answers.semi ? "always" : "never"],
+            },
+        }
+
+        if (answers.modules) {
+            set(config, "parserOptions.sourceType", "module")
+        }
+        if (answers.es2015) {
+            set(config, "parserOptions.ecmaVersion", 2015)
+            set(config, "env.es6", true)
+        }
+        if (answers.commonjs) {
+            set(config, "env.commonjs", true)
+        }
+        for (const env of answers.envs) {
+            set(config, `env.${env}`, true)
+        }
+
+        if (answers.jsx) {
+            set(config, "parserOptions.ecmaFeatures.jsx", true)
+        }
+        if (answers.react) {
+            config.extends.push("plugin:react/recommended")
+            config.plugins = ["react"]
+            set(config, "parserOptions.ecmaFeatures.experimentalObjectRestSpread", true)
+        }
+
+        return config
+    })

--- a/lib/init/prompt-format.js
+++ b/lib/init/prompt-format.js
@@ -1,0 +1,107 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const fs = require("fs")
+const inquirer = require("inquirer")
+const get = require("lodash/get")
+const semver = require("semver")
+const fetchPluginsAndConfigs = require("./npm-util/fetch-plugins-and-configs")
+
+/**
+ * Read a file as JSON.
+ * @param {string} filePath The path to the target file.
+ * @returns {any} The data of the file.
+ */
+function readJSON(filePath) {
+    return new Promise((resolve, reject) => {
+        fs.readFile(filePath, "utf8", (readError, jsonText) => {
+            if (readError != null) {
+                reject(readError)
+                return
+            }
+
+            try {
+                resolve(JSON.parse(jsonText.trim() || "{}"))
+            }
+            catch (parseError) {
+                reject(parseError)
+            }
+        })
+    })
+}
+
+/**
+ * Check whether the local ESLint version conflicts with the required version of the current config.
+ * @param {object} context The context info.
+ * @param {string} context.cwd The path to the current working directory.
+ * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} context.log The function to display log messages.
+ * @param {object} config The config object.
+ * @param {object} answers The answers object. This adds two properties to this object.
+ * @returns {Promise<boolean>} `true` if the local ESLint is found then it conflicts with the required version.
+ */
+function hasESLintVersionConflict(context, config, answers) {
+    // Get the local ESLint version.
+    return readJSON(context.packageJsonPath).then(packageJsonData => {
+        answers.actualVersionRange = get(packageJsonData, "devDependencies.eslint")
+
+        if (semver.validRange(answers.actualVersionRange)) {
+            return fetchPluginsAndConfigs(context, config, true)
+        }
+        return null
+    }).then(packages => {
+        if (packages == null) {
+            return false
+        }
+
+        const eslintId = packages.find(id => id.startsWith("eslint@"))
+        answers.expectedVersionRange = eslintId && eslintId.split("@")[1]
+        if (!semver.validRange(answers.expectedVersionRange)) {
+            return false
+        }
+
+        // Check the version.
+        return !semver.intersects(
+            answers.actualVersionRange,
+            answers.expectedVersionRange
+        )
+    })
+}
+
+/**
+ * Prompt the format to save configuration file.
+ * @param {object} context The context info.
+ * @param {string} context.cwd The path to the current working directory.
+ * @param {string|null} context.packageJsonPath The path to `package.json` file if exists.
+ * @param {function} context.log The function to display log messages.
+ * @param {object} config The config object.
+ * @returns {Promise<{fileType:string,installESLint:boolean}>} The result of the prompt.
+ */
+module.exports = (context, config) =>
+    inquirer.prompt([
+        {
+            type: "list",
+            name: "fileType",
+            message: "What format do you want your config file to be in?",
+            default: ".js",
+            choices: [
+                { name: "JavaScript", value: ".js" },
+                { name: "YAML", value: ".yml" },
+                { name: "JSON", value: ".json" },
+            ],
+        },
+        {
+            type: "confirm",
+            name: "installESLint",
+            default: true,
+            when(answers) {
+                return hasESLintVersionConflict(context, config, answers)
+            },
+            message(answers) {
+                return `It requires 'eslint@${answers.expectedVersionRange}', but you are using 'eslint@${answers.actualVersionRange}'.\n  Do you want to install the proper ESLint?`
+            },
+        },
+    ])

--- a/lib/init/prompt-method.js
+++ b/lib/init/prompt-method.js
@@ -1,0 +1,26 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const inquirer = require("inquirer")
+
+/**
+ * Prompt the method to configure ESLint.
+ * @returns {Promise<{method:string}>} The result of the prompt.
+ */
+module.exports = () =>
+    inquirer.prompt([
+        {
+            type: "list",
+            name: "method",
+            message: "How would you like to configure ESLint?",
+            default: "style",
+            choices: [
+                { name: "Answer questions about your style", value: "style" },
+                { name: "Use a popular style guide", value: "guide" },
+                { name: "Inspect your JavaScript file(s)", value: "files" },
+            ],
+        },
+    ])

--- a/lib/init/save-config-file.js
+++ b/lib/init/save-config-file.js
@@ -8,21 +8,17 @@ const fs = require("fs")
 const path = require("path")
 const debug = require("debug")("eslint-cli")
 const stringify = require("json-stable-stringify")
-const getLocalESLint = require("./get-local-eslint")
+const resolvePath = require("resolve").sync
 
 // Convert a given config object to the string which represents the config.
 const createContentAs = {
     ".js"(config, filePath) {
         const code = `module.exports = ${stringify(config, { space: 4 })};`
         const basedir = path.dirname(filePath)
-        const eslint = getLocalESLint(basedir)
 
-        if (eslint == null) {
-            return code
-        }
-
+        // Fix the code with the given config.
         try {
-            // Fix the code with the given config.
+            const eslint = require(resolvePath("eslint", { basedir }))
             const linter = new eslint.CLIEngine({
                 baseConfig: config,
                 fix: true,

--- a/lib/init/save-config-file.js
+++ b/lib/init/save-config-file.js
@@ -1,0 +1,72 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const fs = require("fs")
+const path = require("path")
+const debug = require("debug")("eslint-cli")
+const stringify = require("json-stable-stringify")
+const getLocalESLint = require("./get-local-eslint")
+
+// Convert a given config object to the string which represents the config.
+const createContentAs = {
+    ".js"(config, filePath) {
+        const code = `module.exports = ${stringify(config, { space: 4 })};`
+        const basedir = path.dirname(filePath)
+        const eslint = getLocalESLint(basedir)
+
+        if (eslint == null) {
+            return code
+        }
+
+        try {
+            // Fix the code with the given config.
+            const linter = new eslint.CLIEngine({
+                baseConfig: config,
+                fix: true,
+                useEslintrc: false,
+            })
+            const report = linter.executeOnText(code)
+
+            return report.results[0].output || code
+        }
+        catch (_err) {
+            // Ignore since this error is trivial.
+            return code
+        }
+    },
+
+    ".yml"(config) {
+        // lazy load YAML to improve performance when not used
+        return require("js-yaml").safeDump(config, { sortKeys: true })
+    },
+
+    ".json"(config) {
+        return stringify(config, { space: 4 })
+    },
+}
+
+/**
+ * Save a given config object.
+ * @param {string} filePath The path to the destination file.
+ * @param {object} config The config object to save.
+ * @returns {Promise<void>} -
+ */
+module.exports = (filePath, config) =>
+    new Promise((resolve, reject) => {
+        debug("SAVE '%s'", filePath)
+
+        const type = path.extname(filePath)
+        const content = createContentAs[type](config, filePath)
+
+        fs.writeFile(filePath, content, (error) => {
+            if (error != null) {
+                reject(error)
+            }
+            else {
+                resolve()
+            }
+        })
+    })

--- a/package.json
+++ b/package.json
@@ -18,8 +18,15 @@
     "lint": "eslint bin lib"
   },
   "dependencies": {
+    "cross-spawn": "^5.1.0",
     "debug": "^3.1.0",
-    "resolve": "^1.3.3"
+    "inquirer": "^3.3.0",
+    "js-yaml": "^3.10.0",
+    "json-stable-stringify": "^1.0.1",
+    "lodash": "^4.17.4",
+    "pkg-up": "^2.0.0",
+    "resolve": "^1.3.3",
+    "semver": "^5.4.1"
   },
   "devDependencies": {
     "eslint": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "js-yaml": "^3.10.0",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.4",
+    "p-queue": "^2.2.0",
     "pkg-up": "^2.0.0",
+    "progress": "^2.0.0",
     "resolve": "^1.3.3",
     "semver": "^5.4.1"
   },


### PR DESCRIPTION
Fixes #4.

This PR adds the feature `eslint --init` into `eslint-cli`.

People can set up ESLint for their project with `eslint --init` command. The command installs `eslint` and necessary plugins into the project local.

However, `eslint-cli` requires local-installed ESLint to use `eslint --init`. This is inconvenient.

```bash
# Do `eslint --init` in order to install ESLint locally!
$ eslint --init
Cannot find local ESLint!
Please install ESLint by `npm install eslint --save-dev`.
```

This PR solves the problem.
Users can use `eslint --init` in order to install ESLint locally.

Also, this should help us that we remove `--init` feature from ESLint core to reduce core size in future.

----

I did refactoring this feature because it has some complex and huge functions.
This is file structure: https://github.com/mysticatea/eslint-cli/tree/init/lib/init