### PR TITLE
Chore: switch to eslint-config-eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-    "extends": ["eslint", "plugin:node/recommended"]
+    "extends": ["eslint", "plugin:node/recommended"],
+    "plugins": ["node"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-    "extends": ["mysticatea", "mysticatea/node"]
+    "extends": ["eslint", "plugin:node/recommended"]
 }

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -3,28 +3,28 @@
  * @author Toru Nagashima
  * See LICENSE file in root directory for full license.
  */
-"use strict"
+"use strict";
 
-const debug = require("debug")("eslint-cli")
-const debugMode = process.argv.indexOf("--debug") !== -1
-const cwd = process.cwd()
+const debug = require("debug")("eslint-cli");
+const debugMode = process.argv.indexOf("--debug") !== -1;
+const cwd = process.cwd();
 
 if (debugMode) {
-    require("debug").enable("eslint-cli")
+    require("debug").enable("eslint-cli");
 }
 
-debug("START", process.argv)
-debug("ROOT", cwd)
+debug("START", process.argv);
+debug("ROOT", cwd);
 
-const binPath = require("../lib/get-local-eslint")(cwd) || require("../lib/get-bin-eslint-js")(cwd)
+const binPath = require("../lib/get-local-eslint")(cwd) || require("../lib/get-bin-eslint-js")(cwd);
+
 if (binPath != null) {
-    require(binPath)
-}
-else {
-    //eslint-disable-next-line no-console
+    require(binPath);
+} else {
+    // eslint-disable-next-line no-console
     console.error(`
 Could not find local ESLint.
 Please install ESLint by 'npm install --save-dev eslint'.
-`)
-    process.exitCode = 1
+`);
+    process.exitCode = 1;
 }

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -18,7 +18,7 @@ debug("ROOT", cwd);
 
 const binPath = require("../lib/get-local-eslint")(cwd) || require("../lib/get-bin-eslint-js")(cwd);
 
-if (binPath != null) {
+if (binPath !== null) {
     require(binPath);
 } else {
     // eslint-disable-next-line no-console

--- a/lib/get-bin-eslint-js.js
+++ b/lib/get-bin-eslint-js.js
@@ -2,11 +2,11 @@
  * @author Toru Nagashima
  * See LICENSE file in root directory for full license.
  */
-"use strict"
+"use strict";
 
-const fs = require("fs")
-const path = require("path")
-const debug = require("debug")("eslint-cli")
+const fs = require("fs");
+const path = require("path");
+const debug = require("debug")("eslint-cli");
 
 /**
  * Finds and tries executing "./bin/eslint.js".
@@ -17,28 +17,30 @@ const debug = require("debug")("eslint-cli")
  * @param {string} basedir - A path of the directory that it starts searching.
  * @returns {string|null} The path of "./bin/eslint.js"
  */
-module.exports = (basedir) => {
-    let dir = basedir
-    let prevDir = dir
+module.exports = basedir => {
+    let dir = basedir;
+    let prevDir = dir;
+
     do {
-        const binPath = path.join(dir, "bin", "eslint.js")
+        const binPath = path.join(dir, "bin", "eslint.js");
+
         if (fs.existsSync(binPath)) {
-            debug("FOUND '%s'", binPath)
-            return binPath
+            debug("FOUND '%s'", binPath);
+            return binPath;
         }
-        debug("NOT FOUND '%s'", binPath)
+        debug("NOT FOUND '%s'", binPath);
 
         // Finish if package.json is found.
         if (fs.existsSync(path.join(dir, "package.json"))) {
-            break
+            break;
         }
 
         // Go to next.
-        prevDir = dir
-        dir = path.resolve(dir, "..")
+        prevDir = dir;
+        dir = path.resolve(dir, "..");
     }
-    while (dir !== prevDir)
+    while (dir !== prevDir);
 
-    debug("NOT FOUND './bin/eslint.js'")
-    return null
-}
+    debug("NOT FOUND './bin/eslint.js'");
+    return null;
+};

--- a/lib/get-local-eslint.js
+++ b/lib/get-local-eslint.js
@@ -2,10 +2,10 @@
  * @author Toru Nagashima <https://github.com/mysticatea>
  * See LICENSE file in root directory for full license.
  */
-"use strict"
+"use strict";
 
-const debug = require("debug")("eslint-cli")
-const resolve = require("resolve")
+const debug = require("debug")("eslint-cli");
+const resolve = require("resolve");
 
 /**
  * Finds and tries executing a local eslint module.
@@ -13,17 +13,17 @@ const resolve = require("resolve")
  * @param {string} basedir - A path of the directory that it starts searching.
  * @returns {string|null} The path of a local eslint module.
  */
-module.exports = (basedir) => {
+module.exports = basedir => {
     try {
-        const binPath = resolve.sync("eslint/bin/eslint.js", { basedir })
-        debug("FOUND '%s'", binPath)
-        return binPath
-    }
-    catch (err) {
+        const binPath = resolve.sync("eslint/bin/eslint.js", { basedir });
+
+        debug("FOUND '%s'", binPath);
+        return binPath;
+    } catch (err) {
         if ((err && err.code) !== "MODULE_NOT_FOUND") {
-            throw err
+            throw err;
         }
-        debug("NOT FOUND 'eslint/bin/eslint.js'")
-        return null
+        debug("NOT FOUND 'eslint/bin/eslint.js'");
+        return null;
     }
-}
+};

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "resolve": "^1.3.3"
   },
   "devDependencies": {
-    "eslint": "^4.10.0",
-    "eslint-config-mysticatea": "^12.0.0"
+    "eslint": "^4.19.1",
+    "eslint-config-eslint": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "eslint": "^4.19.1",
-    "eslint-config-eslint": "^4.0.0"
+    "eslint-config-eslint": "^4.0.0",
+    "eslint-plugin-node": "^6.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
two issues(not autofix):
+ Definition for rule 'node/no-deprecated-api' was not found
```bash
/Users/weiran/repo/eslint-cli/bin/eslint.js
   1:1   error  Definition for rule 'node/no-deprecated-api' was not found        node/no-deprecated-api
   1:1   error  Definition for rule 'node/no-extraneous-require' was not found    node/no-extraneous-require
   1:1   error  Definition for rule 'node/no-missing-require' was not found       node/no-missing-require
   1:1   error  Definition for rule 'node/no-unpublished-bin' was not found       node/no-unpublished-bin
   1:1   error  Definition for rule 'node/no-unpublished-require' was not found   node/no-unpublished-require
   1:1   error  Definition for rule 'node/no-unsupported-features' was not found  node/no-unsupported-features
   1:1   error  Definition for rule 'node/process-exit-as-throw' was not found    node/process-exit-as-throw
   1:1   error  Definition for rule 'node/shebang' was not found                  node/shebang
```
+ eqeqeq
```bash
/Users/weiran/repo/eslint-cli/bin/eslint.js
  21:13  error  Expected '!==' and instead saw '!='  eqeqeq
```