### PR TITLE
New: add --use-global-fallback option

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -5,6 +5,8 @@
  */
 "use strict"
 
+const spawnSync = require("child_process").spawnSync
+
 const debug = require("debug")("eslint-cli")
 const debugMode = process.argv.indexOf("--debug") !== -1
 const cwd = process.cwd()
@@ -16,7 +18,13 @@ if (debugMode) {
 debug("START", process.argv)
 debug("ROOT", cwd)
 
-const binPath = require("../lib/get-local-eslint")(cwd) || require("../lib/get-bin-eslint-js")(cwd)
+const yarnGlobalDir = spawnSync("yarn", ["global", "dir"])
+
+const binPath =
+      require("../lib/get-local-eslint")(cwd) ||
+      require("../lib/get-bin-eslint-js")(cwd) ||
+      (yarnGlobalDir.stdout &&
+       require("../lib/get-local-eslint")(yarnGlobalDir.stdout.toString().trim()))
 if (binPath != null) {
     require(binPath)
 }

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -5,9 +5,6 @@
  */
 "use strict";
 
-const path = require("path");
-const spawnSync = require("child_process").spawnSync;
-
 const debug = require("debug")("eslint-cli");
 const debugMode = process.argv.indexOf("--debug") !== -1;
 const cwd = process.cwd();
@@ -25,15 +22,10 @@ if (binPath !== null) {
     require(binPath);
 } else if (process.argv.includes("--use-global-fallback")) {
     try {
-        const yarnGlobalDir = spawnSync("yarn", ["global", "dir"]);
-
-        if (yarnGlobalDir.stdout) {
-            // eslint do not accept --use-global-fallback
-            process.argv.splice(process.argv.indexOf("--use-global-fallback"), 1);
-            require(path.resolve(
-                yarnGlobalDir.stdout.toString().trim(),
-                "node_modules", "eslint", "bin", "eslint.js"));
-        }
+        // eslint do not accept --use-global-fallback
+        process.argv.splice(process.argv.indexOf("--use-global-fallback"), 1);
+        // eslint-disable-next-line node/no-unpublished-require
+        require("eslint/bin/eslint");
     } catch (err) {
         if ((err && err.code) !== "MODULE_NOT_FOUND") {
             throw err;

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -10,7 +10,6 @@ const spawnSync = require("child_process").spawnSync
 
 const debug = require("debug")("eslint-cli")
 const debugMode = process.argv.indexOf("--debug") !== -1
-const useGlobalFallback = true;
 const cwd = process.cwd()
 
 if (debugMode) {
@@ -25,10 +24,12 @@ const binPath = require("../lib/get-local-eslint")(cwd) || require("../lib/get-b
 if (binPath != null) {
     require(binPath)
 }
-else if (useGlobalFallback) {
+else if (process.argv.includes("--use-global-fallback")) {
     try {
         const yarnGlobalDir = spawnSync("yarn", ["global", "dir"])
         if (yarnGlobalDir.stdout) {
+            // eslint do not accept --use-global-fallback
+            process.argv.splice(process.argv.indexOf("--use-global-fallback"), 1)
             require(path.resolve(
                 yarnGlobalDir.stdout.toString().trim(),
                 "node_modules", "eslint", "bin", "eslint.js"))


### PR DESCRIPTION
ローカルのeslintをプレフィクス無しで起動するには,eslint-cliが必要です.
しかし,eslint-cliをグローバルにインストールすると,グローバルのeslintが上書きされてしまい,グローバルで起動するとeslintは以下のエラーメッセージを出します.

~~~js
% eslint foo.js
Cannot find local ESLint!
Please install ESLint by `npm install eslint --save-dev`.
~~~

これでは,一々package.jsonを作るまでもない単発のjsファイルや,既存の単発のjsファイルを軽く確認したい場合,一々エラー表示に頭を悩ませることになります.

私の場合,Emacsのflycheckを使っているのですが,ESLintが正常に動作しなかったエラー表示を行うので非常に鬱陶しいです.

このpull requestはyarn global以下のESLintも探索対象に加えます.
これにより`yarn global add eslint eslint-cli`しておけば,プロジェクト以下のjsファイルはそのESLint,グローバルの場所のjsファイルはグローバルのESLintを使うことが出来ます.

---

To launch the local eslint without prefix, eslint-cli is required.
However, if you install eslint-cli globally, global eslint will be overwritten, and when invoked globally eslint will issue the following error message.

~~~js
% eslint foo.js
Can not find local ESLint!
Please install ESLint by `npm install eslint --save-dev`.
~~~

With this, when you want to check the single js file or the existing single js file lightly without having to create package.json one by one, you will be bothered by the error display one by one.

In my case, I use Emacs' flycheck, but it is very annoying because it displays an error that ESLint did not work properly.

This pull request also adds ESLint below yarn global to the search target.
If you set `yarn global add eslint eslint-cli`, you can use the ESLint for the js file below the project and the global ESLint for the js file at the global location.